### PR TITLE
Highlight node more explicitly when selected

### DIFF
--- a/graph_ui/js/Graph.js
+++ b/graph_ui/js/Graph.js
@@ -15,7 +15,10 @@ var Graph = React.createClass({
     return {
       options: {
         nodes: {
-          color: '#97C2FC',
+          color: {
+            background: '#97C2FC',
+            highlight: '#45E01E'
+          },
           borderWidth: 0,
           borderWidthSelected: 1,
           shape: 'dot',


### PR DESCRIPTION
This just changes the color when you select a node either through click or search. Before it wasn't as obvious. Now it's a brilliant shade of green!

![image](https://cloud.githubusercontent.com/assets/6600392/14367966/707399fe-fce0-11e5-9d3e-7396582588d0.png)
