### PR TITLE
Fix bug with reset forcing users to refresh page

### DIFF
--- a/graph_ui/js/SearchPanel.js
+++ b/graph_ui/js/SearchPanel.js
@@ -23,6 +23,12 @@ var SearchPanel = React.createClass({
     };
   },
 
+  search: function() {
+    this.props.searchNode(this.state.searchOptions, function() {
+      this.setState(this.getInitialState());      
+    }.bind(this));
+  },
+
   updateFields: function() {
     var self = this;
     this.setState({

--- a/graph_ui/js/app.js
+++ b/graph_ui/js/app.js
@@ -229,18 +229,7 @@ var Graphalyzer = React.createClass({
   },
 
   reset: function() {
-    this.setState({
-      currentGraph: null,
-      filter: {},
-      graphData: {
-        nodes: new Vis.DataSet(),
-        edges: new Vis.DataSet()
-      },
-      tmpGraphData: {},
-      totalChunks: 0,
-      currentChunk: 0,
-      selectedNode: {}
-    });
+    this.setState(this.getInitialState());
   },
 
   searchNode: function(params) {


### PR DESCRIPTION
Something in the state wasn't resetting properly when the Reset Graph button was pressed, forcing users to have to refresh the page.
